### PR TITLE
Fix multiprocessing args issue by using functools.partial

### DIFF
--- a/backup.py
+++ b/backup.py
@@ -2,20 +2,10 @@ import argparse
 import requests
 import os
 import urllib.parse
-from multiprocessing import Pool, TimeoutError
+from multiprocessing import Pool, freeze_support
+from functools import partial
 
-
-my_parser = argparse.ArgumentParser(description='List the content of a folder')
-
-my_parser.add_argument('--api_token', type=str, help='Cloudflare\'s API token')
-my_parser.add_argument('--cf_account_id', type=str, help='Cloudflare\'s account tag')
-my_parser.add_argument('--kv_namespace_id', type=str, help='KV namespace ID')
-my_parser.add_argument('--dest', type=str, help='Dest backup directory', default="./data")
-
-args = my_parser.parse_args()
-
-
-def get(item):
+def get(item, args):
     name = item['name']
     dest = "%s/%s" % (args.dest, name)
     if os.path.exists(dest):
@@ -26,15 +16,15 @@ def get(item):
     url = 'https://api.cloudflare.com/client/v4/accounts/%s/storage/kv/namespaces/%s/values/%s'\
         % (args.cf_account_id, args.kv_namespace_id, urllib.parse.quote(name).replace("/", "%2F"))
     r = requests.get(url, headers=headers)
-    assert r.status_code == 200
+    if r.status_code != 200:
+        print(f"Failed to download {name}. Status code: {r.status_code}, Response: {r.text}")
+        return
     if not os.path.exists(os.path.dirname(dest)):
         os.makedirs(os.path.dirname(dest))
-    f = open(dest, "wb+")
-    f.write(r.content)
-    f.close()
+    with open(dest, "wb+") as f:
+        f.write(r.content)
 
-
-def main():
+def main(args):
     cursor = ""
 
     if not args.api_token:
@@ -54,12 +44,14 @@ def main():
         url = 'https://api.cloudflare.com/client/v4/accounts/%s/storage/kv/namespaces/%s/keys?&cursor=%s'\
                 % (args.cf_account_id, args.kv_namespace_id, cursor)
         r = requests.get(url, headers=headers)
-        assert r.status_code == 200
+        if r.status_code != 200:
+            print(f"Failed to fetch keys. Status code: {r.status_code}, Response: {r.text}")
+            break
 
         d = r.json()
         print("fetched %d keys" % len(d['result']))
 
-        pool.map(get, d['result'])
+        pool.map(partial(get, args=args), d['result'])
 
         if d["result_info"]["cursor"]:
             cursor = d["result_info"]["cursor"]
@@ -69,5 +61,16 @@ def main():
     pool.close()
     pool.terminate()
 
+if __name__ == '__main__':
+    freeze_support()
+    
+    my_parser = argparse.ArgumentParser(description='List the content of a folder')
 
-main()
+    my_parser.add_argument('--api_token', type=str, help='Cloudflare\'s API token')
+    my_parser.add_argument('--cf_account_id', type=str, help='Cloudflare\'s account tag')
+    my_parser.add_argument('--kv_namespace_id', type=str, help='KV namespace ID')
+    my_parser.add_argument('--dest', type=str, help='Dest backup directory', default="./data")
+
+    args = my_parser.parse_args()
+    
+    main(args)


### PR DESCRIPTION
This PR addresses several issues and improvements in the `kv-backup` script. Below is a detailed summary of the changes made:

#### 1. **Multiprocessing Args Issue**
- **Problem**: The `args` variable was not accessible within the `get` function when executed by the multiprocessing pool, causing a `NameError: name 'args' is not defined`.
- **Solution**: Used `functools.partial` to pass the `args` variable explicitly to the `get` function. This ensures that the `args` variable is available within the `get` function when it is executed by the multiprocessing pool.

#### 2. **Error Handling and Debugging Information**
- **Problem**: The script did not provide sufficient information when HTTP requests failed, making it difficult to diagnose issues.
- **Solution**: Added print statements to display the status code and response content when HTTP requests fail. This helps in diagnosing why the request is failing.
- **Changes**:
  ```python
  def get(item, args):
      # (existing code)
      r = requests.get(url, headers=headers)
      if r.status_code != 200:
          print(f"Failed to download {name}. Status code: {r.status_code}, Response: {r.text}")
          return
      # (existing code)
  
  def main(args):
      # (existing code)
      while True:
          # (existing code)
          r = requests.get(url, headers=headers)
          if r.status_code != 200:
              print(f"Failed to fetch keys. Status code: {r.status_code}, Response: {r.text}")
              break
          # (existing code)
  ```

### Summary
This PR fixes multiple issues in the `kv-backup` script, including:
- Passing the `args` variable to the `get` function using `functools.partial` to resolve the `NameError`.
- Adding error handling and debugging information for HTTP requests.